### PR TITLE
circle 2.0 and new cc test reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/circuitry-seismograph
+    docker:
+      - image: kapost/ruby:2.4.3-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: install cc-test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
+      - run:
+          name: Rspec
+          command: |
+            bundle exec rspec --format documentation --color spec
+            ./cc-test-reporter after-build --exit-code $?

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  ruby:
-    version: 2.3.0
-
-dependencies:
-  pre:
-    - gem install bundler -v 1.11.2

--- a/circuitry-seismograph.gemspec
+++ b/circuitry-seismograph.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'seismograph', '~> 0.3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.2.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'circuitry/seismograph'


### PR DESCRIPTION
Circle is sunsetting 1.0 builds and configs effective August 31, 2018. This gets circuitry-seismograph on circle 2.0

Also, just like [circuitry-middleware](https://github.com/kapost/circuitry-middleware/pull/5) the codeclimate reporter gem is now deprecated and unusable in builds, so updated that as well.